### PR TITLE
Rename OnBecomeCurrent to OnMakeCurrent.

### DIFF
--- a/gl.go
+++ b/gl.go
@@ -37,8 +37,8 @@ var ContextWatcher contextWatcher
 
 type contextWatcher struct{}
 
-func (contextWatcher) OnBecomeCurrent(context interface{}) {}
-func (contextWatcher) OnDetach()                           {}
+func (contextWatcher) OnMakeCurrent(context interface{}) {}
+func (contextWatcher) OnDetach()                         {}
 
 // ActiveTexture sets the active texture unit.
 //

--- a/gl_windows.go
+++ b/gl_windows.go
@@ -16,7 +16,7 @@ var ContextWatcher contextWatcher
 
 type contextWatcher struct{}
 
-func (contextWatcher) OnBecomeCurrent(context interface{}) {
+func (contextWatcher) OnMakeCurrent(context interface{}) {
 	// Initialise gl bindings using the current context.
 	err := gl.Init()
 	if err != nil {

--- a/glweb.go
+++ b/glweb.go
@@ -14,7 +14,7 @@ var ContextWatcher contextWatcher
 
 type contextWatcher struct{}
 
-func (contextWatcher) OnBecomeCurrent(context interface{}) {
+func (contextWatcher) OnMakeCurrent(context interface{}) {
 	// context must be a WebGLRenderingContext *js.Object.
 	c = context.(*js.Object)
 }


### PR DESCRIPTION
This is more consistent with the terminology used upstream.

Depends on https://github.com/goxjs/glfw/pull/5.
